### PR TITLE
Add Playwright web client regression suite

### DIFF
--- a/tests/web/README.md
+++ b/tests/web/README.md
@@ -1,0 +1,35 @@
+# Web client regression tests
+
+Playwright-based end-to-end tests for the web client (`web/`).
+
+## Setup
+```
+npm i playwright
+npx playwright install chromium firefox
+```
+
+## Running
+The tests require:
+1. `bin/server_bin` listening on `localhost:8085`.
+2. A reverse-proxy that strips the `/tictactoe/` prefix on port `9090` (see `proxy.py`).
+   This is only needed for local single-instance runs — production traffic is
+   already proxied behind `/tictactoe/`. See task for the underlying
+   prefix-mismatch issue.
+
+```
+./bin/server_bin &
+python3 tests/web/proxy.py &
+node tests/web/test_498_mania_self_eviction.js
+node tests/web/test_498_negative.js
+```
+
+## Tests
+- `test_498_mania_self_eviction.js` — regression for the post-update Mania
+  spec change ("self-replace is illegal"). Asserts the player's own
+  about-to-evict cell stays `disabled` and `onCellClick` does not POST
+  even if the disabled gate is bypassed. Will FAIL against previous web
+  client (which still allows the click); will PASS once anvil lands.
+- `test_498_negative.js` — companion. Asserts that with both queues full,
+  only empty cells are clickable for the active player.
+- `test_499_no_fading_after_win.js` — regression for. Asserts no
+  `.fading` cells remain on either client after Mania terminal status.

--- a/tests/web/proxy.py
+++ b/tests/web/proxy.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Tiny reverse proxy: strips /tictactoe prefix and forwards to localhost:8085."""
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import urllib.request, urllib.error
+
+UPSTREAM = "http://localhost:8085"
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, *a, **k):
+        return None
+
+class P(BaseHTTPRequestHandler):
+    def _proxy(self, method):
+        path = self.path
+        if path.startswith("/tictactoe"):
+            path = path[len("/tictactoe"):] or "/"
+        body = None
+        if "Content-Length" in self.headers:
+            body = self.rfile.read(int(self.headers["Content-Length"]))
+        req = urllib.request.Request(UPSTREAM + path, data=body, method=method)
+        for h, v in self.headers.items():
+            if h.lower() in ("host", "content-length", "accept-encoding"):
+                continue
+            req.add_header(h, v)
+        # No-redirect opener so the browser sees raw 302
+        no_redir = urllib.request.build_opener(_NoRedirect)
+        try:
+            r = no_redir.open(req, timeout=10)
+            self.send_response(r.status)
+            for h, v in r.headers.items():
+                if h.lower() in ("transfer-encoding", "connection"):
+                    continue
+                if h.lower() == "location" and v.startswith("/"):
+                    v = "/tictactoe" + v if not v.startswith("/tictactoe") else v
+                self.send_header(h, v)
+            self.end_headers()
+            self.wfile.write(r.read())
+        except urllib.error.HTTPError as e:
+            self.send_response(e.code)
+            for h, v in e.headers.items():
+                if h.lower() in ("transfer-encoding", "connection"):
+                    continue
+                if h.lower() == "location" and v.startswith("/"):
+                    v = "/tictactoe" + v if not v.startswith("/tictactoe") else v
+                self.send_header(h, v)
+            self.end_headers()
+            self.wfile.write(e.read())
+    def do_GET(self): self._proxy("GET")
+    def do_POST(self): self._proxy("POST")
+    def log_message(self, *a, **k): pass
+
+ThreadingHTTPServer(("127.0.0.1", 9090), P).serve_forever()

--- a/tests/web/test_498_mania_self_eviction.js
+++ b/tests/web/test_498_mania_self_eviction.js
@@ -1,0 +1,136 @@
+// Regression test for the post-update Mania spec ("self-replace is illegal").
+//
+// Under the new rule, a Mania player MAY NOT place on their own
+// about-to-evict cell. The web client therefore must:
+//   * keep that cell `disabled` even when it's the player's turn;
+//   * `onCellClick` must short-circuit if it somehow fires (no POST, no
+//     optimistic preview).
+//
+// This file replaces the prior-era assertion (which asserted the
+// opposite behavior — legal under the old spec, illegal under the new one).
+// See task for the implementation, for the spec change.
+//
+// Run: see tests/web/README.md.
+
+const { chromium, firefox } = require('playwright');
+const BASE = 'http://localhost:9090/tictactoe';
+
+async function createGame(page, name) {
+  await page.goto(BASE + '/create-game');
+  await page.fill('#createName', name);
+  await page.check('input[name="mode"][value="mania"]');
+  await page.click('#createBtn');
+  await page.waitForURL(/\/play\/\d{4}/, { timeout: 10000 });
+  return page.url().match(/\/play\/(\d{4})/)[1];
+}
+async function joinGame(page, name, gid) {
+  await page.goto(BASE + '/create-game');
+  await page.fill('#joinName', name);
+  await page.fill('#joinGameId', gid);
+  await page.click('#joinBtn');
+  await page.waitForURL(/\/play\/\d{4}/, { timeout: 10000 });
+}
+async function waitMyTurn(p, t = 10000) {
+  await p.waitForFunction(
+    () => /Your turn/.test((document.getElementById('statusText') || {}).textContent || ''),
+    { timeout: t },
+  );
+}
+async function play(p, pos) {
+  await p.click(`.cell[data-pos="${pos}"]`, { timeout: 5000 });
+}
+
+(async () => {
+  const failures = [];
+  const cb = await chromium.launch();
+  const fb = await firefox.launch();
+  try {
+    const host = await (await cb.newContext()).newPage();
+    const guest = await (await fb.newContext()).newPage();
+
+    const gid = await createGame(host, 'Alice');
+    await joinGame(guest, 'Bob', gid);
+    await waitMyTurn(host);
+
+    // Drive both players' queues to full without producing a winning line.
+    const seq = [
+      [host, 0], [guest, 1],
+      [host, 5], [guest, 2],
+      [host, 7], [guest, 8],
+    ];
+    for (const [p, pos] of seq) {
+      await waitMyTurn(p);
+      await play(p, pos);
+      await p.waitForTimeout(250);
+    }
+    await waitMyTurn(host);
+
+    // Precondition: .fading should still mark Alice's about-to-evict cell.
+    // The fading indicator is independent of the legality flip — it names
+    // the cell that WILL be evicted on her next valid placement.
+    const fading = await host.evaluate(() =>
+      Array.from(document.querySelectorAll('.cell.fading')).map(c => c.dataset.pos),
+    );
+    if (JSON.stringify(fading) !== JSON.stringify(['0'])) {
+      failures.push(`expected .fading=['0'], got ${JSON.stringify(fading)}`);
+    }
+
+    // New-spec assertion #1: the about-to-evict cell stays disabled.
+    const cellInfo = await host.evaluate(() => {
+      const c = document.querySelector('.cell[data-pos="0"]');
+      return { disabled: c.disabled, text: c.textContent };
+    });
+    if (cellInfo.disabled !== true) {
+      failures.push(`pos 0 (Alice's about-to-evict) must be disabled; got disabled=${cellInfo.disabled}`);
+    }
+    if (cellInfo.text !== 'X') {
+      failures.push(`pos 0 should still hold 'X' before any further move; got '${cellInfo.text}'`);
+    }
+
+    // New-spec assertion #2: forcing onCellClick must NOT POST a self-replace
+    // move. Even if a user bypassed the `disabled` attribute (e.g., via devtools),
+    // game.js should short-circuit and never send the request.
+    const apiBefore = await host.evaluate(async () => {
+      const gid = window.location.pathname.split('/').pop();
+      const r = await fetch('/tictactoe/api/game/' + gid);
+      return r.json();
+    });
+    await host.evaluate(() => {
+      const c = document.querySelector('.cell[data-pos="0"]');
+      c.disabled = false;       // bypass the visual gate
+      c.click();                // fire onCellClick directly
+    });
+    await host.waitForTimeout(500);
+    const apiAfter = await host.evaluate(async () => {
+      const gid = window.location.pathname.split('/').pop();
+      const r = await fetch('/tictactoe/api/game/' + gid);
+      return r.json();
+    });
+    if (apiBefore.moveHistory.length !== apiAfter.moveHistory.length) {
+      failures.push(
+        `moveHistory length changed after bypassed click: ${apiBefore.moveHistory.length} -> ${apiAfter.moveHistory.length} (server accepted a self-replace, or client POSTed something else)`,
+      );
+    }
+    if (apiAfter.currentTurn !== 0) {
+      failures.push(`turn rotated away from Alice (currentTurn=${apiAfter.currentTurn}); the click should have been a no-op`);
+    }
+    const myTurnStill = await host.evaluate(
+      () => /Your turn/.test(document.getElementById('statusText').textContent || ''),
+    );
+    if (!myTurnStill) {
+      failures.push(`status banner left "Your turn" after no-op click`);
+    }
+  } catch (e) {
+    failures.push(`[CRASH] ${e.stack || e.message}`);
+  } finally {
+    await cb.close();
+    await fb.close();
+  }
+
+  if (failures.length) {
+    console.log('REGRESSION self-replace-illegal — FAIL:');
+    for (const f of failures) console.log('  ' + f);
+    process.exit(1);
+  }
+  console.log('REGRESSION self-replace-illegal — PASS');
+})();

--- a/tests/web/test_498_negative.js
+++ b/tests/web/test_498_negative.js
@@ -1,0 +1,68 @@
+// Negative-side regression for the post-update Mania spec.
+//
+// Under the new rule ("self-replace is illegal"), every occupied cell is
+// disabled when it's the player's turn, including their own about-to-evict
+// cell. Only empty cells are clickable.
+const { chromium, firefox } = require('playwright');
+const assert = require('assert');
+const BASE = 'http://localhost:9090/tictactoe';
+
+async function createGame(page, name, mode) {
+  await page.goto(BASE + '/create-game');
+  await page.fill('#createName', name);
+  if (mode === 'mania') await page.check('input[name="mode"][value="mania"]');
+  await page.click('#createBtn');
+  await page.waitForURL(/\/play\/\d{4}/, { timeout: 10000 });
+  return page.url().match(/\/play\/(\d{4})/)[1];
+}
+async function joinGame(page, name, gid) {
+  await page.goto(BASE + '/create-game');
+  await page.fill('#joinName', name);
+  await page.fill('#joinGameId', gid);
+  await page.click('#joinBtn');
+  await page.waitForURL(/\/play\/\d{4}/, { timeout: 10000 });
+}
+async function waitMyTurn(p, t=10000) {
+  await p.waitForFunction(() => /Your turn/.test((document.getElementById('statusText')||{}).textContent||''), {timeout:t});
+}
+async function play(p, pos) { await p.click(`.cell[data-pos="${pos}"]`); }
+
+(async () => {
+  const failures = [];
+  const cb = await chromium.launch();
+  const fb = await firefox.launch();
+  try {
+    const host = await (await cb.newContext()).newPage();
+    const guest = await (await fb.newContext()).newPage();
+    const gid = await createGame(host, 'AliceN', 'mania');
+    await joinGame(guest, 'BobN', gid);
+    await waitMyTurn(host);
+    const seq = [[host,0],[guest,1],[host,5],[guest,2],[host,7],[guest,8]];
+    for (const [p, pos] of seq) {
+      await waitMyTurn(p);
+      await play(p, pos);
+      await p.waitForTimeout(250);
+    }
+    await waitMyTurn(host);
+
+    // Under the post-update spec ALL occupied cells are disabled, including
+    // Alice's about-to-evict cell at pos 0. Only empty cells (3, 4, 6) are clickable.
+    const disabledMap = await host.evaluate(() =>
+      Array.from(document.querySelectorAll('.cell')).map(c => ({
+        pos: c.dataset.pos, disabled: c.disabled, text: c.textContent,
+      }))
+    );
+    console.log('cell state for Alice (her turn, queue full, nextEv=0):');
+    console.log(disabledMap);
+    const expectedDisabled = { '0': true, '1': true, '2': true, '3': false, '4': false, '5': true, '6': false, '7': true, '8': true };
+    for (const c of disabledMap) {
+      if (c.disabled !== expectedDisabled[c.pos]) {
+        failures.push(`cell ${c.pos} (text="${c.text}"): disabled=${c.disabled}, expected=${expectedDisabled[c.pos]}`);
+      }
+    }
+  } catch (e) { failures.push('[CRASH] ' + (e.stack||e.message)); }
+  finally { await cb.close(); await fb.close(); }
+
+  if (failures.length) { console.log('NEGATIVE — FAIL:'); for (const f of failures) console.log('  '+f); process.exit(1); }
+  console.log('NEGATIVE — PASS (only empty cells are enabled)');
+})();

--- a/tests/web/test_499_no_fading_after_win.js
+++ b/tests/web/test_499_no_fading_after_win.js
@@ -1,0 +1,71 @@
+// Regression test for:
+// .fading must be cleared on every cell once the game reaches a terminal
+// status (winner/tie/finished). Mania, of course, never reaches "tie".
+//
+// Run: see tests/web/README.md.
+
+const { chromium, firefox } = require('playwright');
+const BASE = 'http://localhost:9090/tictactoe';
+
+async function createGame(page, name, mode) {
+  await page.goto(BASE + '/create-game');
+  await page.fill('#createName', name);
+  if (mode === 'mania') await page.check('input[name="mode"][value="mania"]');
+  await page.click('#createBtn');
+  await page.waitForURL(/\/play\/\d{4}/, { timeout: 10000 });
+  return page.url().match(/\/play\/(\d{4})/)[1];
+}
+async function joinGame(page, name, gid) {
+  await page.goto(BASE + '/create-game');
+  await page.fill('#joinName', name);
+  await page.fill('#joinGameId', gid);
+  await page.click('#joinBtn');
+  await page.waitForURL(/\/play\/\d{4}/, { timeout: 10000 });
+}
+async function waitMyTurn(p, t=10000) {
+  await p.waitForFunction(() => /Your turn/.test((document.getElementById('statusText')||{}).textContent||''), {timeout:t});
+}
+async function waitTerminal(p, t=10000) {
+  await p.waitForFunction(() => /won|wins|tie|finished/i.test((document.getElementById('statusText')||{}).textContent||''), {timeout:t});
+}
+async function play(p, pos) { await p.click(`.cell[data-pos="${pos}"]`); }
+async function fadingCount(p) {
+  return p.evaluate(() => document.querySelectorAll('.cell.fading').length);
+}
+
+(async () => {
+  const failures = [];
+  const cb = await chromium.launch();
+  const fb = await firefox.launch();
+  try {
+    const host = await (await cb.newContext()).newPage();
+    const guest = await (await fb.newContext()).newPage();
+    const gid = await createGame(host, 'AliceF', 'mania');
+    await joinGame(guest, 'BobF', gid);
+    await waitMyTurn(host);
+    // Drive host to a top-row win on the 3rd X move (X@0, X@1, X@2),
+    // with Bob filling 3,4 (no win for O). Bob's queue won't be full
+    // by the time Alice wins, so .fading should already be absent or
+    // confined to Alice's nextEviction; either way, we check
+    // post-terminal that nothing is .fading.
+    await play(host, 0); await waitMyTurn(guest);
+    await play(guest, 3); await waitMyTurn(host);
+    await play(host, 1); await waitMyTurn(guest);
+    await play(guest, 4); await waitMyTurn(host);
+    await play(host, 2); // top-row win for X
+    await waitTerminal(host);
+    await waitTerminal(guest);
+
+    // Give one extra poll cycle to land.
+    await host.waitForTimeout(300);
+
+    const hostFade = await fadingCount(host);
+    const guestFade = await fadingCount(guest);
+    if (hostFade !== 0) failures.push(`host still has ${hostFade} .fading cells after win`);
+    if (guestFade !== 0) failures.push(`guest still has ${guestFade} .fading cells after win`);
+  } catch (e) { failures.push('[CRASH] ' + (e.stack||e.message)); }
+  finally { await cb.close(); await fb.close(); }
+
+  if (failures.length) { console.log('REGRESSION — FAIL:'); for (const f of failures) console.log('  '+f); process.exit(1); }
+  console.log('REGRESSION — PASS');
+})();


### PR DESCRIPTION
New tests/web/ harness with proxy.py and regression tests for issues #498 (mania self-eviction) and #499 (post-win fading).